### PR TITLE
Fixed build issues

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,8 +35,7 @@ lib_deps =
   #SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
   #SailfishRGB_LED=https://github.com/mikeshub/SailfishRGB_LED/archive/master.zip
   SlowSoftI2CMaster=https://github.com/mikeshub/SlowSoftI2CMaster/archive/master.zip
-  libmaple=https://github.com/pasyn/libmaple/archive/master.zip
-  STM32F1=https://github.com/pasyn/stm32f1/archive/master.zip
+
 
 
 # Globally defined properties

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,12 +29,15 @@ lib_deps =
   TMCStepper=https://github.com/bigtreetech/TMCStepper
   #Adafruit NeoPixel
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  Adafruit_MAX31865=https://github.com/adafruit/Adafruit_MAX31865/archive/master.zip
+  Adafruit_MAX31865=https://github.com/adafruit/Adafruit_MAX31865/archive/1.1.0.zip
   LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
   Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/0.8.0.zip
   #SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
   #SailfishRGB_LED=https://github.com/mikeshub/SailfishRGB_LED/archive/master.zip
   SlowSoftI2CMaster=https://github.com/mikeshub/SlowSoftI2CMaster/archive/master.zip
+  libmaple=https://github.com/pasyn/libmaple/archive/master.zip
+  STM32F1=https://github.com/pasyn/stm32f1/archive/master.zip
+
 
 # Globally defined properties
 # inherited by all environments
@@ -323,8 +326,11 @@ monitor_speed     = 115200
 [env:STM32F103RC_btt_512K]
 platform          = ststm32
 board             = genericSTM32F103RC
+board_build.core = maple
 board_upload.maximum_size=524288
-platform_packages = tool-stm32duino
+platform_packages =
+   tool-stm32duino
+   framework-arduinoststm32-maple
 build_flags       = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=512
 build_unflags     = -std=gnu++11


### PR DESCRIPTION

### Description


Fixed build issues caused by missing packages and broken compatibility with Adafruit_MAX31865.


### Benefits

Code builds successfully! Hurray! 

### Related Issues

Adafruit_MAX31865 master branch introduced changes that broke compatibility therefore we are using v1.1.0 instead. Also changed platformio.ini config to use maple core and the framework-arduinostm32-maple platform package which fixes the "libmaple/gpio.h: file not found" compiling error.