### PR TITLE
Change INVERT_X_DIR values

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1311,9 +1311,9 @@
 // @section machine
 
 // Invert the stepper direction. Change (or reverse the motor connector) if an axis goes the wrong way.
-#define INVERT_X_DIR false
-#define INVERT_Y_DIR false
-#define INVERT_Z_DIR true
+#define INVERT_X_DIR true
+#define INVERT_Y_DIR true
+#define INVERT_Z_DIR false
 //#define INVERT_I_DIR false
 //#define INVERT_J_DIR false
 //#define INVERT_K_DIR false


### PR DESCRIPTION
### Description

Printer goes faster to the wrong way where there was no endpoints. 

It is solved by changing the following lines as follows:
#define INVERT_X_DIR true
#define INVERT_Y_DIR true
#define INVERT_Z_DIR false

### Requirements

Marlin firmware
Ender 3 pro
SKR MINI E3 V1.2

### Benefits

More Ender 3 users have correct values like with other online firmware configurations versions.